### PR TITLE
r.tg.geom.html: HTML fixes

### DIFF
--- a/r.tg.geom.html
+++ b/r.tg.geom.html
@@ -8,12 +8,14 @@ suggested settings.
 
 <h2>NOTES</h2>
 
-The tool defines the locally significant ridgeline-to-channel spacing by calculating relative relief values with nested neighborhood matrices.<br>
-Relative relief values are plotted against corresponding neighborhood matrice areas and breaks of curve are detected where the convex change of curve is sharpest.
+The tool defines the locally significant ridgeline-to-channel spacing by
+calculating relative relief values with nested neighborhood matrices.<br>
+Relative relief values are plotted against corresponding neighborhood matrice
+areas and breaks of curve are detected where the convex change of curve is sharpest.
 
 <h3>Dependencies:</h3>
 
-R 3.x (packages: spgrass6/rgrass7, ggplot2, plyr) & r.geomorphon add-on
+R 3.x (packages: spgrass6/rgrass7, ggplot2, plyr) &amp; r.geomorphon add-on
 
 <h2>SEE ALSO</h2>
 
@@ -24,17 +26,17 @@ R 3.x (packages: spgrass6/rgrass7, ggplot2, plyr) & r.geomorphon add-on
 <h2>REFERENCES</h2>
 
 <ul>
-<li>Mark, D.M., 1975. Geomorphometric parameters: a review and evaluation. Geografiska Annaler. Series A, Physical Geography, Vol. 57, # No. 3/4 (1975), pp. 165-177.</li>
+<li>Mark, D.M., 1975. Geomorphometric parameters: a review and evaluation.
+    Geografiska Annaler. Series A, Physical Geography, Vol. 57, # No. 3/4 (1975), pp. 165-177.</li>
 <li>Pike, R.J., Acevedo,W., Card, D.H., 1989. Topographic grain automated from digital elevation models.
 In: Proceedings of the Ninth International Symposium on Computer Assisted Cartogtraphy.</li>
 SPRS/ASCM, Baltimore, MD, pp. 128-137.
 </ul>
 
 <h2>AUTHORS</h2>
+
 Edina Jozsa<br>
-<i>University of Pécs (Hungary)</i><br>
+<i>University of P&#233;cs (Hungary)</i><br>
+
 Adriana Sarasan<br>
 <i>West University of Timisoara (Romania)</i><br>
-
-<p>
-<i>Last changed: $Date: 2017-03-19 (Sun, 19 March 2017) $</i>


### PR DESCRIPTION
- change encoding from ISO-8859-1 to UTF-8
- fix special char
- break long lines following https://trac.osgeo.org/grass/wiki/Submitting/Docs#HTMLPages